### PR TITLE
[UNIATA] fix for uninitialized Lun pointer, CORE-15886

### DIFF
--- a/drivers/storage/ide/uniata/id_init.cpp
+++ b/drivers/storage/ide/uniata/id_init.cpp
@@ -1251,6 +1251,7 @@ for_ugly_chips:
 
             for(c=0; c<deviceExtension->NumberChannels; c++) {
                 chan = &deviceExtension->chan[c];
+                AtapiSetupLunPtrs(chan, deviceExtension, c);
                 IsPata = FALSE;
                 if(ChipFlags & ICH5) {
                     KdPrint2((PRINT_PREFIX "ICH5\n"));

--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -43,7 +43,7 @@ Used Version: 1.0.6
 Website: http://www.bzip.org
 
 Title: LibXML
-Used Version: 2.9.8
+Used Version: 2.9.9
 Website: http://xmlsoft.org | ftp://xmlsoft.org/libxml2/
 
 Title: Libxslt

--- a/sdk/include/reactos/libs/libxml/globals.h
+++ b/sdk/include/reactos/libs/libxml/globals.h
@@ -17,7 +17,6 @@
 #include <libxml/xmlversion.h>
 #include <libxml/parser.h>
 #include <libxml/xmlerror.h>
-#include <libxml/SAX.h>
 #include <libxml/SAX2.h>
 #include <libxml/xmlmemory.h>
 

--- a/sdk/include/reactos/libs/libxml/tree.h
+++ b/sdk/include/reactos/libs/libxml/tree.h
@@ -575,7 +575,7 @@ struct _xmlDoc {
     void           *ids;        /* Hash table for ID attributes if any */
     void           *refs;       /* Hash table for IDREFs attributes if any */
     const xmlChar  *URL;	/* The URI for that document */
-    int             charset;    /* encoding of the in-memory content
+    int             charset;    /* Internal flag for charset handling,
 				   actually an xmlCharEncoding */
     struct _xmlDict *dict;      /* dict used to allocate names or NULL */
     void           *psvi;	/* for type/PSVI informations */

--- a/sdk/include/reactos/libs/libxml/xmlexports.h
+++ b/sdk/include/reactos/libs/libxml/xmlexports.h
@@ -131,8 +131,8 @@
   #endif
 #endif
 
-/* Cygwin platform, GNU compiler */
-#if defined(_WIN32) && defined(__CYGWIN__)
+/* Cygwin platform (does not define _WIN32), GNU compiler */
+#if defined(__CYGWIN__)
   #undef XMLPUBFUN
   #undef XMLPUBVAR
   #undef XMLCALL
@@ -145,7 +145,7 @@
     #if !defined(LIBXML_STATIC)
       #define XMLPUBVAR __declspec(dllimport) extern
     #else
-      #define XMLPUBVAR
+      #define XMLPUBVAR extern
     #endif
   #endif
   #define XMLCALL __cdecl

--- a/sdk/include/reactos/libs/libxml/xmlversion.h
+++ b/sdk/include/reactos/libs/libxml/xmlversion.h
@@ -29,28 +29,28 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.8"
+#define LIBXML_DOTTED_VERSION "2.9.9"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20908
+#define LIBXML_VERSION 20909
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20908"
+#define LIBXML_VERSION_STRING "20909"
 
 /**
  * LIBXML_VERSION_EXTRA:
  *
  * extra version information, used to show a CVS compilation
  */
-#define LIBXML_VERSION_EXTRA "-GITv2.9.8-rc1-2-gd910e99c3"
+#define LIBXML_VERSION_EXTRA "-GITv2.9.9-rc2-2-g7c4949afa"
 
 /**
  * LIBXML_TEST_VERSION:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20908);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20909);
 
 #ifndef VMS
 #if 0

--- a/sdk/lib/3rdparty/libxml2/HTMLparser.c
+++ b/sdk/lib/3rdparty/libxml2/HTMLparser.c
@@ -1084,7 +1084,7 @@ static const char * const htmlStartClose[] = {
 "menu",		"p", "head", "ul", NULL,
 "p",		"p", "head", "h1", "h2", "h3", "h4", "h5", "h6", FONTSTYLE, NULL,
 "div",		"p", "head", NULL,
-"noscript",	"p", NULL,
+"noscript",	"script", NULL,
 "center",	"font", "b", "i", "p", "head", NULL,
 "a",		"a", "head", NULL,
 "caption",	"p", NULL,
@@ -3635,13 +3635,13 @@ htmlCheckEncodingDirect(htmlParserCtxtPtr ctxt, const xmlChar *encoding) {
 	     */
 	    processed = ctxt->input->cur - ctxt->input->base;
 	    xmlBufShrink(ctxt->input->buf->buffer, processed);
-	    nbchars = xmlCharEncInput(ctxt->input->buf, 0);
+	    nbchars = xmlCharEncInput(ctxt->input->buf, 1);
+            xmlBufResetInput(ctxt->input->buf->buffer, ctxt->input);
 	    if (nbchars < 0) {
 		htmlParseErr(ctxt, XML_ERR_INVALID_ENCODING,
 		             "htmlCheckEncoding: encoder error\n",
 			     NULL, NULL);
 	    }
-            xmlBufResetInput(ctxt->input->buf->buffer, ctxt->input);
 	}
     }
 }

--- a/sdk/lib/3rdparty/libxml2/HTMLtree.c
+++ b/sdk/lib/3rdparty/libxml2/HTMLtree.c
@@ -502,15 +502,15 @@ htmlNodeDumpFileFormat(FILE *out, xmlDocPtr doc,
 	    if (handler == NULL)
 		htmlSaveErr(XML_SAVE_UNKNOWN_ENCODING, NULL, encoding);
 	}
+    } else {
+        /*
+         * Fallback to HTML or ASCII when the encoding is unspecified
+         */
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("HTML");
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("ascii");
     }
-
-    /*
-     * Fallback to HTML or ASCII when the encoding is unspecified
-     */
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("ascii");
 
     /*
      * save the content to a temp buffer.
@@ -570,32 +570,21 @@ htmlDocDumpMemoryFormat(xmlDocPtr cur, xmlChar**mem, int *size, int format) {
 	xmlCharEncoding enc;
 
 	enc = xmlParseCharEncoding(encoding);
-	if (enc != cur->charset) {
-	    if (cur->charset != XML_CHAR_ENCODING_UTF8) {
-		/*
-		 * Not supported yet
-		 */
-		*mem = NULL;
-		*size = 0;
-		return;
-	    }
-
+	if (enc != XML_CHAR_ENCODING_UTF8) {
 	    handler = xmlFindCharEncodingHandler(encoding);
 	    if (handler == NULL)
                 htmlSaveErr(XML_SAVE_UNKNOWN_ENCODING, NULL, encoding);
 
-	} else {
-	    handler = xmlFindCharEncodingHandler(encoding);
 	}
+    } else {
+        /*
+         * Fallback to HTML or ASCII when the encoding is unspecified
+         */
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("HTML");
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("ascii");
     }
-
-    /*
-     * Fallback to HTML or ASCII when the encoding is unspecified
-     */
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("ascii");
 
     buf = xmlAllocOutputBufferInternal(handler);
     if (buf == NULL) {
@@ -1101,29 +1090,20 @@ htmlDocDump(FILE *f, xmlDocPtr cur) {
 	xmlCharEncoding enc;
 
 	enc = xmlParseCharEncoding(encoding);
-	if (enc != cur->charset) {
-	    if (cur->charset != XML_CHAR_ENCODING_UTF8) {
-		/*
-		 * Not supported yet
-		 */
-		return(-1);
-	    }
-
+	if (enc != XML_CHAR_ENCODING_UTF8) {
 	    handler = xmlFindCharEncodingHandler(encoding);
 	    if (handler == NULL)
 		htmlSaveErr(XML_SAVE_UNKNOWN_ENCODING, NULL, encoding);
-	} else {
-	    handler = xmlFindCharEncodingHandler(encoding);
 	}
+    } else {
+        /*
+         * Fallback to HTML or ASCII when the encoding is unspecified
+         */
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("HTML");
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("ascii");
     }
-
-    /*
-     * Fallback to HTML or ASCII when the encoding is unspecified
-     */
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("ascii");
 
     buf = xmlOutputBufferCreateFile(f, handler);
     if (buf == NULL) return(-1);
@@ -1160,27 +1140,20 @@ htmlSaveFile(const char *filename, xmlDocPtr cur) {
 	xmlCharEncoding enc;
 
 	enc = xmlParseCharEncoding(encoding);
-	if (enc != cur->charset) {
-	    if (cur->charset != XML_CHAR_ENCODING_UTF8) {
-		/*
-		 * Not supported yet
-		 */
-		return(-1);
-	    }
-
+	if (enc != XML_CHAR_ENCODING_UTF8) {
 	    handler = xmlFindCharEncodingHandler(encoding);
 	    if (handler == NULL)
 		htmlSaveErr(XML_SAVE_UNKNOWN_ENCODING, NULL, encoding);
 	}
+    } else {
+        /*
+         * Fallback to HTML or ASCII when the encoding is unspecified
+         */
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("HTML");
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("ascii");
     }
-
-    /*
-     * Fallback to HTML or ASCII when the encoding is unspecified
-     */
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("ascii");
 
     /*
      * save the content to a temp buffer.
@@ -1221,14 +1194,7 @@ htmlSaveFileFormat(const char *filename, xmlDocPtr cur,
 	xmlCharEncoding enc;
 
 	enc = xmlParseCharEncoding(encoding);
-	if (enc != cur->charset) {
-	    if (cur->charset != XML_CHAR_ENCODING_UTF8) {
-		/*
-		 * Not supported yet
-		 */
-		return(-1);
-	    }
-
+	if (enc != XML_CHAR_ENCODING_UTF8) {
 	    handler = xmlFindCharEncodingHandler(encoding);
 	    if (handler == NULL)
 		htmlSaveErr(XML_SAVE_UNKNOWN_ENCODING, NULL, encoding);
@@ -1236,15 +1202,15 @@ htmlSaveFileFormat(const char *filename, xmlDocPtr cur,
         htmlSetMetaEncoding(cur, (const xmlChar *) encoding);
     } else {
 	htmlSetMetaEncoding(cur, (const xmlChar *) "UTF-8");
-    }
 
-    /*
-     * Fallback to HTML or ASCII when the encoding is unspecified
-     */
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("HTML");
-    if (handler == NULL)
-	handler = xmlFindCharEncodingHandler("ascii");
+        /*
+         * Fallback to HTML or ASCII when the encoding is unspecified
+         */
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("HTML");
+        if (handler == NULL)
+            handler = xmlFindCharEncodingHandler("ascii");
+    }
 
     /*
      * save the content to a temp buffer.

--- a/sdk/lib/3rdparty/libxml2/SAX2.c
+++ b/sdk/lib/3rdparty/libxml2/SAX2.c
@@ -1665,7 +1665,11 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
 #ifdef DEBUG_SAX_TREE
     xmlGenericError(xmlGenericErrorContext, "pushing(%s)\n", name);
 #endif
-    nodePush(ctxt, ret);
+    if (nodePush(ctxt, ret) < 0) {
+        xmlUnlinkNode(ret);
+        xmlFreeNode(ret);
+        return;
+    }
 
     /*
      * Link the child element
@@ -2257,6 +2261,7 @@ xmlSAX2StartElementNs(void *ctx,
 	ctxt->freeElems = ret->next;
 	ctxt->freeElemsNr--;
 	memset(ret, 0, sizeof(xmlNode));
+        ret->doc = ctxt->myDoc;
 	ret->type = XML_ELEMENT_NODE;
 
 	if (ctxt->dictNames)
@@ -2336,7 +2341,11 @@ xmlSAX2StartElementNs(void *ctx,
     /*
      * We are parsing a new node.
      */
-    nodePush(ctxt, ret);
+    if (nodePush(ctxt, ret) < 0) {
+        xmlUnlinkNode(ret);
+        xmlFreeNode(ret);
+        return;
+    }
 
     /*
      * Link the child element

--- a/sdk/lib/3rdparty/libxml2/c14n.c
+++ b/sdk/lib/3rdparty/libxml2/c14n.c
@@ -1798,15 +1798,6 @@ xmlC14NNewCtx(xmlDocPtr doc,
     }
 
     /*
-     *  Validate the XML document encoding value, if provided.
-     */
-    if (doc->charset != XML_CHAR_ENCODING_UTF8) {
-        xmlC14NErr(ctx, (xmlNodePtr) doc, XML_C14N_REQUIRES_UTF8,
-		   "xmlC14NNewCtx: source document not in UTF8\n");
-        return (NULL);
-    }
-
-    /*
      * Allocate a new xmlC14NCtxPtr and fill the fields.
      */
     ctx = (xmlC14NCtxPtr) xmlMalloc(sizeof(xmlC14NCtx));

--- a/sdk/lib/3rdparty/libxml2/config.h
+++ b/sdk/lib/3rdparty/libxml2/config.h
@@ -267,7 +267,7 @@
 /* #undef VA_LIST_IS_ARRAY */
 
 /* Version number of package */
-#define VERSION "2.9.8"
+#define VERSION "2.9.9"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T int

--- a/sdk/lib/3rdparty/libxml2/encoding.c
+++ b/sdk/lib/3rdparty/libxml2/encoding.c
@@ -2460,8 +2460,6 @@ retry:
         ret = -3;
     }
 
-    if (ret >= 0) output += ret;
-
     /*
      * Attempt to handle error cases
      */

--- a/sdk/lib/3rdparty/libxml2/parser.c
+++ b/sdk/lib/3rdparty/libxml2/parser.c
@@ -12462,7 +12462,12 @@ xmlHaltParser(xmlParserCtxtPtr ctxt) {
 	    ctxt->input->free((xmlChar *) ctxt->input->base);
 	    ctxt->input->free = NULL;
 	}
+        if (ctxt->input->buf != NULL) {
+            xmlFreeParserInputBuffer(ctxt->input->buf);
+            ctxt->input->buf = NULL;
+        }
 	ctxt->input->cur = BAD_CAST"";
+        ctxt->input->length = 0;
 	ctxt->input->base = ctxt->input->cur;
         ctxt->input->end = ctxt->input->cur;
     }

--- a/sdk/lib/3rdparty/libxml2/parserInternals.c
+++ b/sdk/lib/3rdparty/libxml2/parserInternals.c
@@ -1214,7 +1214,7 @@ xmlSwitchInputEncodingInt(xmlParserCtxtPtr ctxt, xmlParserInputPtr input,
                 /*
                  * convert as much as possible of the buffer
                  */
-                nbchars = xmlCharEncInput(input->buf, 0);
+                nbchars = xmlCharEncInput(input->buf, 1);
             } else {
                 /*
                  * convert just enough to get
@@ -1240,8 +1240,18 @@ xmlSwitchInputEncodingInt(xmlParserCtxtPtr ctxt, xmlParserInputPtr input,
 	 * size to be able to convert the buffer.
 	 */
 	xmlErrInternal(ctxt, "switching encoding : no input\n", NULL);
+        /*
+         * Callers assume that the input buffer takes ownership of the
+         * encoding handler. xmlCharEncCloseFunc frees unregistered
+         * handlers and avoids a memory leak.
+         */
+        xmlCharEncCloseFunc(handler);
 	return (-1);
     }
+    /*
+     * We should actually raise an error here, see issue #34.
+     */
+    xmlCharEncCloseFunc(handler);
     return (0);
 }
 

--- a/sdk/lib/3rdparty/libxml2/uri.c
+++ b/sdk/lib/3rdparty/libxml2/uri.c
@@ -2236,25 +2236,8 @@ xmlBuildRelativeURI (const xmlChar * URI, const xmlChar * base)
      * First we take care of the special case where either of the
      * two path components may be missing (bug 316224)
      */
-    if (bas->path == NULL) {
-	if (ref->path != NULL) {
-	    uptr = (xmlChar *) ref->path;
-	    if (*uptr == '/')
-		uptr++;
-	    /* exception characters from xmlSaveUri */
-	    val = xmlURIEscapeStr(uptr, BAD_CAST "/;&=+$,");
-	}
-	goto done;
-    }
     bptr = (xmlChar *)bas->path;
-    if (ref->path == NULL) {
-	for (ix = 0; bptr[ix] != 0; ix++) {
-	    if (bptr[ix] == '/')
-		nbslash++;
-	}
-	uptr = NULL;
-	len = 1;	/* this is for a string terminator only */
-    } else {
+    {
         xmlChar *rptr = (xmlChar *) ref->path;
         int pos = 0;
 
@@ -2280,30 +2263,28 @@ xmlBuildRelativeURI (const xmlChar * URI, const xmlChar * base)
 	 * beginning of the "unique" suffix of URI
 	 */
 	ix = pos;
-	if ((rptr[ix] == '/') && (ix > 0))
-	    ix--;
-	else if ((rptr[ix] == 0) && (ix > 1) && (rptr[ix - 1] == '/'))
-	    ix -= 2;
 	for (; ix > 0; ix--) {
-	    if (rptr[ix] == '/')
+	    if (rptr[ix - 1] == '/')
 		break;
 	}
-	if (ix == 0) {
-	    uptr = (xmlChar *)rptr;
-	} else {
-	    ix++;
-	    uptr = (xmlChar *)&rptr[ix];
-	}
+	uptr = (xmlChar *)&rptr[ix];
 
 	/*
 	 * In base, count the number of '/' from the differing point
 	 */
-	if (bptr[pos] != rptr[pos]) {/* check for trivial URI == base */
-	    for (; bptr[ix] != 0; ix++) {
-		if (bptr[ix] == '/')
-		    nbslash++;
-	    }
+	for (; bptr[ix] != 0; ix++) {
+	    if (bptr[ix] == '/')
+		nbslash++;
 	}
+
+	/*
+	 * e.g: URI="foo/" base="foo/bar" -> "./"
+	 */
+	if (nbslash == 0 && !uptr[0]) {
+	    val = xmlStrdup(BAD_CAST "./");
+	    goto done;
+	}
+
 	len = xmlStrlen (uptr) + 1;
     }
 

--- a/sdk/lib/3rdparty/libxml2/xmlIO.c
+++ b/sdk/lib/3rdparty/libxml2/xmlIO.c
@@ -3161,7 +3161,7 @@ xmlParserInputBufferPush(xmlParserInputBufferPtr in,
 	 * convert as much as possible to the parser reading buffer.
 	 */
 	use = xmlBufUse(in->raw);
-	nbchars = xmlCharEncInput(in, 0);
+	nbchars = xmlCharEncInput(in, 1);
 	if (nbchars < 0) {
 	    xmlIOErr(XML_IO_ENCODER, NULL);
 	    in->error = XML_IO_ENCODER;
@@ -3277,7 +3277,7 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
 	 * convert as much as possible to the parser reading buffer.
 	 */
 	use = xmlBufUse(in->raw);
-	nbchars = xmlCharEncInput(in, 0);
+	nbchars = xmlCharEncInput(in, 1);
 	if (nbchars < 0) {
 	    xmlIOErr(XML_IO_ENCODER, NULL);
 	    in->error = XML_IO_ENCODER;

--- a/sdk/lib/3rdparty/libxml2/xmllint.c
+++ b/sdk/lib/3rdparty/libxml2/xmllint.c
@@ -2071,51 +2071,52 @@ static void doXPathDump(xmlXPathObjectPtr cur) {
             int i;
             xmlNodePtr node;
 #ifdef LIBXML_OUTPUT_ENABLED
-            xmlSaveCtxtPtr ctxt;
+            xmlOutputBufferPtr buf;
 
             if ((cur->nodesetval == NULL) || (cur->nodesetval->nodeNr <= 0)) {
                 fprintf(stderr, "XPath set is empty\n");
                 progresult = XMLLINT_ERR_XPATH;
                 break;
             }
-            ctxt = xmlSaveToFd(1, NULL, 0);
-            if (ctxt == NULL) {
+            buf = xmlOutputBufferCreateFile(stdout, NULL);
+            if (buf == NULL) {
                 fprintf(stderr, "Out of memory for XPath\n");
                 progresult = XMLLINT_ERR_MEM;
                 return;
             }
             for (i = 0;i < cur->nodesetval->nodeNr;i++) {
                 node = cur->nodesetval->nodeTab[i];
-                xmlSaveTree(ctxt, node);
+                xmlNodeDumpOutput(buf, node->doc, node, 0, 0, NULL);
+                xmlOutputBufferWrite(buf, 1, "\n");
             }
-            xmlSaveClose(ctxt);
+            xmlOutputBufferClose(buf);
 #else
             printf("xpath returned %d nodes\n", cur->nodesetval->nodeNr);
 #endif
 	    break;
         }
         case XPATH_BOOLEAN:
-	    if (cur->boolval) printf("true");
-	    else printf("false");
+	    if (cur->boolval) printf("true\n");
+	    else printf("false\n");
 	    break;
         case XPATH_NUMBER:
 	    switch (xmlXPathIsInf(cur->floatval)) {
 	    case 1:
-		printf("Infinity");
+		printf("Infinity\n");
 		break;
 	    case -1:
-		printf("-Infinity");
+		printf("-Infinity\n");
 		break;
 	    default:
 		if (xmlXPathIsNaN(cur->floatval)) {
-		    printf("NaN");
+		    printf("NaN\n");
 		} else {
-		    printf("%0g", cur->floatval);
+		    printf("%0g\n", cur->floatval);
 		}
 	    }
 	    break;
         case XPATH_STRING:
-	    printf("%s", (const char *) cur->stringval);
+	    printf("%s\n", (const char *) cur->stringval);
 	    break;
         case XPATH_UNDEFINED:
 	    fprintf(stderr, "XPath Object is uninitialized\n");

--- a/sdk/lib/3rdparty/libxml2/xmlreader.c
+++ b/sdk/lib/3rdparty/libxml2/xmlreader.c
@@ -1711,10 +1711,11 @@ xmlTextReaderReadInnerXml(xmlTextReaderPtr reader ATTRIBUTE_UNUSED)
     if (xmlTextReaderExpand(reader) == NULL) {
         return NULL;
     }
-    doc = reader->doc;
+    doc = reader->node->doc;
     buff = xmlBufferCreate();
     for (cur_node = reader->node->children; cur_node != NULL;
          cur_node = cur_node->next) {
+        /* XXX: Why is the node copied? */
         node = xmlDocCopyNode(cur_node, doc, 1);
         buff2 = xmlBufferCreate();
         if (xmlNodeDump(buff2, doc, node, 0, 0) == -1) {
@@ -1755,10 +1756,11 @@ xmlTextReaderReadOuterXml(xmlTextReaderPtr reader ATTRIBUTE_UNUSED)
     xmlDocPtr doc;
 
     node = reader->node;
-    doc = reader->doc;
+    doc = node->doc;
     if (xmlTextReaderExpand(reader) == NULL) {
         return NULL;
     }
+    /* XXX: Why is the node copied? */
 	if (node->type == XML_DTD_NODE) {
 		node = (xmlNodePtr) xmlCopyDtd((xmlDtdPtr) node);
 	} else {
@@ -1917,12 +1919,9 @@ xmlTextReaderNextTree(xmlTextReaderPtr reader)
 
 	/* if reader->node->next is NULL mean no subtree for current node,
 	so need to move to sibling of parent node if present */
-        if ((reader->node->type == XML_ELEMENT_NODE) ||
-            (reader->node->type == XML_ATTRIBUTE_NODE)) {
-            reader->state = XML_TEXTREADER_BACKTRACK;
-	    /* This will move to parent if present */
-            xmlTextReaderRead(reader);
-        }
+	reader->state = XML_TEXTREADER_BACKTRACK;
+	/* This will move to parent if present */
+	xmlTextReaderRead(reader);
     }
 
     if (reader->node->next != 0) {
@@ -3006,7 +3005,7 @@ xmlTextReaderAttributeCount(xmlTextReaderPtr reader) {
  * Reference:
  * http://www.gnu.org/software/dotgnu/pnetlib-doc/System/Xml/XmlNodeType.html
  *
- * Returns the xmlNodeType of the current node or -1 in case of error
+ * Returns the xmlReaderTypes of the current node or -1 in case of error
  */
 int
 xmlTextReaderNodeType(xmlTextReaderPtr reader) {

--- a/sdk/lib/3rdparty/libxml2/xmlsave.c
+++ b/sdk/lib/3rdparty/libxml2/xmlsave.c
@@ -1123,9 +1123,6 @@ xmlDocContentDumpOutput(xmlSaveCtxtPtr ctxt, xmlDocPtr cur) {
         cur->encoding = BAD_CAST ctxt->encoding;
     } else if (cur->encoding != NULL) {
 	encoding = cur->encoding;
-    } else if (cur->charset != XML_CHAR_ENCODING_UTF8) {
-	encoding = (const xmlChar *)
-		     xmlGetCharEncodingName((xmlCharEncoding) cur->charset);
     }
 
     if (((cur->type == XML_HTML_DOCUMENT_NODE) &&

--- a/sdk/lib/3rdparty/libxml2/xmlschemas.c
+++ b/sdk/lib/3rdparty/libxml2/xmlschemas.c
@@ -27653,6 +27653,17 @@ xmlSchemaClearValidCtxt(xmlSchemaValidCtxtPtr vctxt)
 	vctxt->nbIdcNodes = 0;
 	vctxt->sizeIdcNodes = 0;
     }
+
+    if (vctxt->idcKeys != NULL) {
+	int i;
+	for (i = 0; i < vctxt->nbIdcKeys; i++)
+	    xmlSchemaIDCFreeKey(vctxt->idcKeys[i]);
+	xmlFree(vctxt->idcKeys);
+	vctxt->idcKeys = NULL;
+	vctxt->nbIdcKeys = 0;
+	vctxt->sizeIdcKeys = 0;
+    }
+
     /*
     * Note that we won't delete the XPath state pool here.
     */

--- a/sdk/lib/3rdparty/libxml2/xpath.c
+++ b/sdk/lib/3rdparty/libxml2/xpath.c
@@ -2,7 +2,7 @@
  * xpath.c: XML Path Language implementation
  *          XPath is a language for addressing parts of an XML document,
  *          designed to be used by both XSLT and XPointer
- *f
+ *
  * Reference: W3C Recommendation 16 November 1999
  *     http://www.w3.org/TR/1999/REC-xpath-19991116
  * Public reference:
@@ -477,27 +477,28 @@ int wrap_cmp( xmlNodePtr x, xmlNodePtr y );
  *									*
  ************************************************************************/
 
-#ifndef NAN
-#define NAN (0.0 / 0.0)
-#endif
-
 #ifndef INFINITY
-#define INFINITY HUGE_VAL
+#define INFINITY (DBL_MAX * DBL_MAX)
 #endif
 
-double xmlXPathNAN = NAN;
-double xmlXPathPINF = INFINITY;
-double xmlXPathNINF = -INFINITY;
+#ifndef NAN
+#define NAN (INFINITY / INFINITY)
+#endif
+
+double xmlXPathNAN;
+double xmlXPathPINF;
+double xmlXPathNINF;
 
 /**
  * xmlXPathInit:
  *
  * Initialize the XPath environment
- *
- * Does nothing but must be kept as public function.
  */
 void
 xmlXPathInit(void) {
+    xmlXPathNAN = NAN;
+    xmlXPathPINF = INFINITY;
+    xmlXPathNINF = -INFINITY;
 }
 
 /**
@@ -526,9 +527,9 @@ xmlXPathIsInf(double val) {
 #ifdef isinf
     return isinf(val) ? (val > 0 ? 1 : -1) : 0;
 #else
-    if (val >= HUGE_VAL)
+    if (val >= INFINITY)
         return 1;
-    if (val <= -HUGE_VAL)
+    if (val <= -INFINITY)
         return -1;
     return 0;
 #endif
@@ -867,15 +868,14 @@ typedef enum {
     XPATH_OP_UNION,
     XPATH_OP_ROOT,
     XPATH_OP_NODE,
-    XPATH_OP_RESET, /* 10 */
     XPATH_OP_COLLECT,
-    XPATH_OP_VALUE, /* 12 */
+    XPATH_OP_VALUE, /* 11 */
     XPATH_OP_VARIABLE,
     XPATH_OP_FUNCTION,
     XPATH_OP_ARG,
     XPATH_OP_PREDICATE,
-    XPATH_OP_FILTER, /* 17 */
-    XPATH_OP_SORT /* 18 */
+    XPATH_OP_FILTER, /* 16 */
+    XPATH_OP_SORT /* 17 */
 #ifdef LIBXML_XPTR_ENABLED
     ,XPATH_OP_RANGETO
 #endif
@@ -1525,8 +1525,6 @@ xmlXPathDebugDumpStepOp(FILE *output, xmlXPathCompExprPtr comp,
 	     fprintf(output, "ROOT"); break;
         case XPATH_OP_NODE:
 	     fprintf(output, "NODE"); break;
-        case XPATH_OP_RESET:
-	     fprintf(output, "RESET"); break;
         case XPATH_OP_SORT:
 	     fprintf(output, "SORT"); break;
         case XPATH_OP_COLLECT: {
@@ -8479,9 +8477,8 @@ void
 xmlXPathRoot(xmlXPathParserContextPtr ctxt) {
     if ((ctxt == NULL) || (ctxt->context == NULL))
 	return;
-    ctxt->context->node = (xmlNodePtr) ctxt->context->doc;
     valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
-	ctxt->context->node));
+	(xmlNodePtr) ctxt->context->doc));
 }
 
 /************************************************************************
@@ -10734,7 +10731,6 @@ xmlXPathCompPathExpr(xmlXPathParserContextPtr ctxt) {
 
 	    PUSH_LONG_EXPR(XPATH_OP_COLLECT, AXIS_DESCENDANT_OR_SELF,
 		    NODE_TEST_TYPE, NODE_TYPE_NODE, NULL, NULL);
-	    PUSH_UNARY_EXPR(XPATH_OP_RESET, ctxt->comp->last, 1, 0);
 
 	    xmlXPathCompRelativeLocationPath(ctxt);
 	} else if (CUR == '/') {
@@ -11665,6 +11661,7 @@ xmlXPathCompOpEvalPredicate(xmlXPathParserContextPtr ctxt,
 	xmlXPathContextPtr xpctxt = ctxt->context;
 	xmlNodePtr contextNode, oldContextNode;
 	xmlDocPtr oldContextDoc;
+        int oldcs, oldpp;
 	int i, res, contextPos = 0, newContextSize;
 	xmlXPathStepOpPtr exprOp;
 	xmlXPathObjectPtr contextObj = NULL, exprRes = NULL;
@@ -11701,6 +11698,8 @@ xmlXPathCompOpEvalPredicate(xmlXPathParserContextPtr ctxt,
 	*/
 	oldContextNode = xpctxt->node;
 	oldContextDoc = xpctxt->doc;
+        oldcs = xpctxt->contextSize;
+        oldpp = xpctxt->proximityPosition;
 	/*
 	* Get the expression of this predicate.
 	*/
@@ -11787,8 +11786,8 @@ evaluation_exit:
 	*/
 	xpctxt->node = oldContextNode;
 	xpctxt->doc = oldContextDoc;
-	xpctxt->contextSize = -1;
-	xpctxt->proximityPosition = -1;
+	xpctxt->contextSize = oldcs;
+	xpctxt->proximityPosition = oldpp;
 	return(newContextSize);
     }
     return(contextSize);
@@ -11831,6 +11830,7 @@ xmlXPathCompOpEvalPositionalPredicate(xmlXPathParserContextPtr ctxt,
 	return (contextSize);
     } else {
 	xmlDocPtr oldContextDoc;
+        int oldcs, oldpp;
 	int i, pos = 0, newContextSize = 0, contextPos = 0, res;
 	xmlXPathStepOpPtr exprOp;
 	xmlXPathObjectPtr contextObj = NULL, exprRes = NULL;
@@ -11851,6 +11851,8 @@ xmlXPathCompOpEvalPositionalPredicate(xmlXPathParserContextPtr ctxt,
 	*/
 	oldContextNode = xpctxt->node;
 	oldContextDoc = xpctxt->doc;
+        oldcs = xpctxt->contextSize;
+        oldpp = xpctxt->proximityPosition;
 	/*
 	* Get the expression of this predicate.
 	*/
@@ -11987,8 +11989,8 @@ evaluation_exit:
 	*/
 	xpctxt->node = oldContextNode;
 	xpctxt->doc = oldContextDoc;
-	xpctxt->contextSize = -1;
-	xpctxt->proximityPosition = -1;
+	xpctxt->contextSize = oldcs;
+	xpctxt->proximityPosition = oldpp;
 	return(newContextSize);
     }
     return(contextSize);
@@ -12778,15 +12780,6 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
 	    valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
 		ctxt->context->node));
             return (total);
-        case XPATH_OP_RESET:
-            if (op->ch1 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
-	    CHECK_ERROR0;
-            if (op->ch2 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-	    CHECK_ERROR0;
-            ctxt->context->node = NULL;
-            return (total);
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
                     return (total);
@@ -12842,10 +12835,6 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
     int total = 0, cur;
     xmlXPathCompExprPtr comp;
     xmlXPathObjectPtr arg1, arg2;
-    xmlNodePtr bak;
-    xmlDocPtr bakd;
-    int pp;
-    int cs;
 
     CHECK_ERROR0;
     comp = ctxt->comp;
@@ -12853,10 +12842,6 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
         case XPATH_OP_END:
             return (0);
         case XPATH_OP_UNION:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total =
                 xmlXPathCompOpEvalLast(ctxt, &comp->steps[op->ch1], last);
 	    CHECK_ERROR0;
@@ -12874,10 +12859,6 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
                                                      nodesetval->nodeNr -
                                                      1];
             }
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             cur =
                 xmlXPathCompOpEvalLast(ctxt, &comp->steps[op->ch2], last);
 	    CHECK_ERROR0;
@@ -12916,15 +12897,6 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
 	    CHECK_ERROR0;
 	    valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
 		ctxt->context->node));
-            return (total);
-        case XPATH_OP_RESET:
-            if (op->ch1 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
-	    CHECK_ERROR0;
-            if (op->ch2 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-	    CHECK_ERROR0;
-            ctxt->context->node = NULL;
             return (total);
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
@@ -12970,6 +12942,7 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
     xmlNodeSetPtr oldset;
     xmlNodePtr oldnode;
     xmlDocPtr oldDoc;
+    int oldcs, oldpp;
     int i;
 
     CHECK_ERROR0;
@@ -13021,7 +12994,6 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 	return (total);
 
 #ifdef LIBXML_XPTR_ENABLED
-    oldnode = ctxt->context->node;
     /*
     * Hum are we filtering the result of an XPointer expression
     */
@@ -13036,23 +13008,17 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 	* up a new locset.
 	*/
 	CHECK_TYPE0(XPATH_LOCATIONSET);
+
+	if ((ctxt->value->user == NULL) ||
+            (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
+	    return (total);
+
 	obj = valuePop(ctxt);
 	oldlocset = obj->user;
-	ctxt->context->node = NULL;
+        oldnode = ctxt->context->node;
+        oldcs = ctxt->context->contextSize;
+        oldpp = ctxt->context->proximityPosition;
 
-	if ((oldlocset == NULL) || (oldlocset->locNr == 0)) {
-	    ctxt->context->contextSize = 0;
-	    ctxt->context->proximityPosition = 0;
-	    if (op->ch2 != -1)
-		total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-	    res = valuePop(ctxt);
-	    if (res != NULL) {
-		xmlXPathReleaseObject(ctxt->context, res);
-	    }
-	    valuePush(ctxt, obj);
-	    CHECK_ERROR0;
-	    return (total);
-	}
 	newlocset = xmlXPtrLocationSetCreate(NULL);
 
 	for (i = 0; i < oldlocset->locNr; i++) {
@@ -13076,8 +13042,8 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 	    if (op->ch2 != -1)
 		total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    if (ctxt->error != XPATH_EXPRESSION_OK) {
-		xmlXPathFreeObject(obj);
-		return(0);
+                xmlXPtrFreeLocationSet(newlocset);
+                goto xptr_error;
 	    }
 	    /*
 	    * The result of the evaluation need to be tested to
@@ -13105,7 +13071,6 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 		/* OLD: xmlXPathFreeObject(res); */
 	    } else
 		tmp = NULL;
-	    ctxt->context->node = NULL;
 	    /*
 	    * Only put the first node in the result, then leave.
 	    */
@@ -13120,12 +13085,12 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 	/*
 	* The result is used as the new evaluation locset.
 	*/
-	xmlXPathReleaseObject(ctxt->context, obj);
-	ctxt->context->node = NULL;
-	ctxt->context->contextSize = -1;
-	ctxt->context->proximityPosition = -1;
 	valuePush(ctxt, xmlXPtrWrapLocationSet(newlocset));
+xptr_error:
+	xmlXPathReleaseObject(ctxt->context, obj);
 	ctxt->context->node = oldnode;
+	ctxt->context->contextSize = oldcs;
+	ctxt->context->proximityPosition = oldpp;
 	return (total);
     }
 #endif /* LIBXML_XPTR_ENABLED */
@@ -13136,32 +13101,19 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
     * up a new set.
     */
     CHECK_TYPE0(XPATH_NODESET);
-    obj = valuePop(ctxt);
-    oldset = obj->nodesetval;
 
-    oldnode = ctxt->context->node;
-    oldDoc = ctxt->context->doc;
-    ctxt->context->node = NULL;
-
-    if ((oldset == NULL) || (oldset->nodeNr == 0)) {
-	ctxt->context->contextSize = 0;
-	ctxt->context->proximityPosition = 0;
-	/* QUESTION TODO: Why was this code commented out?
-	    if (op->ch2 != -1)
-		total +=
-		    xmlXPathCompOpEval(ctxt,
-			&comp->steps[op->ch2]);
-	    CHECK_ERROR0;
-	    res = valuePop(ctxt);
-	    if (res != NULL)
-		xmlXPathFreeObject(res);
-	*/
-	valuePush(ctxt, obj);
-	ctxt->context->node = oldnode;
-	CHECK_ERROR0;
-    } else {
+    if ((ctxt->value->nodesetval != NULL) &&
+        (ctxt->value->nodesetval->nodeNr != 0)) {
 	xmlNodeSetPtr newset;
 	xmlXPathObjectPtr tmp = NULL;
+
+        obj = valuePop(ctxt);
+        oldset = obj->nodesetval;
+        oldnode = ctxt->context->node;
+        oldDoc = ctxt->context->doc;
+        oldcs = ctxt->context->contextSize;
+        oldpp = ctxt->context->proximityPosition;
+
 	/*
 	* Initialize the new set.
 	* Also set the xpath document in case things like
@@ -13195,8 +13147,7 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 		total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    if (ctxt->error != XPATH_EXPRESSION_OK) {
 		xmlXPathFreeNodeSet(newset);
-		xmlXPathFreeObject(obj);
-		return(0);
+                goto error;
 	    }
 	    /*
 	    * The result of the evaluation needs to be tested to
@@ -13223,7 +13174,6 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 		xmlXPathNodeSetClear(tmp->nodesetval, 1);
 	    } else
 		tmp = NULL;
-	    ctxt->context->node = NULL;
 	    /*
 	    * Only put the first node in the result, then leave.
 	    */
@@ -13238,15 +13188,14 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 	/*
 	* The result is used as the new evaluation set.
 	*/
-	xmlXPathReleaseObject(ctxt->context, obj);
-	ctxt->context->node = NULL;
-	ctxt->context->contextSize = -1;
-	ctxt->context->proximityPosition = -1;
-	/* may want to move this past the '}' later */
-	ctxt->context->doc = oldDoc;
 	valuePush(ctxt, xmlXPathCacheWrapNodeSet(ctxt->context, newset));
+error:
+	xmlXPathReleaseObject(ctxt->context, obj);
+	ctxt->context->node = oldnode;
+	ctxt->context->doc = oldDoc;
+	ctxt->context->contextSize = oldcs;
+	ctxt->context->proximityPosition = oldpp;
     }
-    ctxt->context->node = oldnode;
     return(total);
 }
 #endif /* XP_OPTIMIZED_FILTER_FIRST */
@@ -13266,10 +13215,6 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
     int equal, ret;
     xmlXPathCompExprPtr comp;
     xmlXPathObjectPtr arg1, arg2;
-    xmlNodePtr bak;
-    xmlDocPtr bakd;
-    int pp;
-    int cs;
 
     CHECK_ERROR0;
     comp = ctxt->comp;
@@ -13277,68 +13222,42 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
         case XPATH_OP_END:
             return (0);
         case XPATH_OP_AND:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
             xmlXPathBooleanFunction(ctxt, 1);
             if ((ctxt->value == NULL) || (ctxt->value->boolval == 0))
                 return (total);
             arg2 = valuePop(ctxt);
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    if (ctxt->error) {
 		xmlXPathFreeObject(arg2);
 		return(0);
 	    }
             xmlXPathBooleanFunction(ctxt, 1);
-            arg1 = valuePop(ctxt);
-            arg1->boolval &= arg2->boolval;
-            valuePush(ctxt, arg1);
+            if (ctxt->value != NULL)
+                ctxt->value->boolval &= arg2->boolval;
 	    xmlXPathReleaseObject(ctxt->context, arg2);
             return (total);
         case XPATH_OP_OR:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
             xmlXPathBooleanFunction(ctxt, 1);
             if ((ctxt->value == NULL) || (ctxt->value->boolval == 1))
                 return (total);
             arg2 = valuePop(ctxt);
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    if (ctxt->error) {
 		xmlXPathFreeObject(arg2);
 		return(0);
 	    }
             xmlXPathBooleanFunction(ctxt, 1);
-            arg1 = valuePop(ctxt);
-            arg1->boolval |= arg2->boolval;
-            valuePush(ctxt, arg1);
+            if (ctxt->value != NULL)
+                ctxt->value->boolval |= arg2->boolval;
 	    xmlXPathReleaseObject(ctxt->context, arg2);
             return (total);
         case XPATH_OP_EQUAL:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    CHECK_ERROR0;
 	    if (op->value)
@@ -13348,33 +13267,17 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
 	    valuePush(ctxt, xmlXPathCacheNewBoolean(ctxt->context, equal));
             return (total);
         case XPATH_OP_CMP:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    CHECK_ERROR0;
             ret = xmlXPathCompareValues(ctxt, op->value, op->value2);
 	    valuePush(ctxt, xmlXPathCacheNewBoolean(ctxt->context, ret));
             return (total);
         case XPATH_OP_PLUS:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
             if (op->ch2 != -1) {
-		ctxt->context->doc = bakd;
-		ctxt->context->node = bak;
-		ctxt->context->proximityPosition = pp;
-		ctxt->context->contextSize = cs;
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    }
 	    CHECK_ERROR0;
@@ -13390,16 +13293,8 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
             }
             return (total);
         case XPATH_OP_MULT:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    CHECK_ERROR0;
             if (op->value == 0)
@@ -13410,16 +13305,8 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 xmlXPathModValues(ctxt);
             return (total);
         case XPATH_OP_UNION:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
 	    CHECK_ERROR0;
-	    ctxt->context->doc = bakd;
-	    ctxt->context->node = bak;
-	    ctxt->context->proximityPosition = pp;
-	    ctxt->context->contextSize = cs;
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
 	    CHECK_ERROR0;
 
@@ -13455,15 +13342,6 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
 	    CHECK_ERROR0;
 	    valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
 		ctxt->context->node));
-            return (total);
-        case XPATH_OP_RESET:
-            if (op->ch1 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
-	    CHECK_ERROR0;
-            if (op->ch2 != -1)
-                total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-	    CHECK_ERROR0;
-            ctxt->context->node = NULL;
             return (total);
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
@@ -13583,24 +13461,12 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 return (total);
             }
         case XPATH_OP_ARG:
-	    bakd = ctxt->context->doc;
-	    bak = ctxt->context->node;
-	    pp = ctxt->context->proximityPosition;
-	    cs = ctxt->context->contextSize;
             if (op->ch1 != -1) {
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
-                ctxt->context->contextSize = cs;
-                ctxt->context->proximityPosition = pp;
-                ctxt->context->node = bak;
-                ctxt->context->doc = bakd;
 	        CHECK_ERROR0;
             }
             if (op->ch2 != -1) {
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-                ctxt->context->contextSize = cs;
-                ctxt->context->proximityPosition = pp;
-                ctxt->context->node = bak;
-                ctxt->context->doc = bakd;
 	        CHECK_ERROR0;
 	    }
             return (total);
@@ -13612,6 +13478,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 xmlNodeSetPtr oldset;
                 xmlNodePtr oldnode;
 		xmlDocPtr oldDoc;
+                int oldcs, oldpp;
                 int i;
 
                 /*
@@ -13714,8 +13581,6 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 if (ctxt->value == NULL)
                     return (total);
 
-                oldnode = ctxt->context->node;
-
 #ifdef LIBXML_XPTR_ENABLED
                 /*
                  * Hum are we filtering the result of an XPointer expression
@@ -13730,25 +13595,17 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                      * up a new locset.
                      */
                     CHECK_TYPE0(XPATH_LOCATIONSET);
+
+                    if ((ctxt->value->user == NULL) ||
+                        (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
+                        return (total);
+
                     obj = valuePop(ctxt);
                     oldlocset = obj->user;
-                    ctxt->context->node = NULL;
+                    oldnode = ctxt->context->node;
+                    oldcs = ctxt->context->contextSize;
+                    oldpp = ctxt->context->proximityPosition;
 
-                    if ((oldlocset == NULL) || (oldlocset->locNr == 0)) {
-                        ctxt->context->contextSize = 0;
-                        ctxt->context->proximityPosition = 0;
-                        if (op->ch2 != -1)
-                            total +=
-                                xmlXPathCompOpEval(ctxt,
-                                                   &comp->steps[op->ch2]);
-                        res = valuePop(ctxt);
-                        if (res != NULL) {
-			    xmlXPathReleaseObject(ctxt->context, res);
-			}
-                        valuePush(ctxt, obj);
-                        CHECK_ERROR0;
-                        return (total);
-                    }
                     newlocset = xmlXPtrLocationSetCreate(NULL);
 
                     for (i = 0; i < oldlocset->locNr; i++) {
@@ -13768,8 +13625,8 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                 xmlXPathCompOpEval(ctxt,
                                                    &comp->steps[op->ch2]);
 			if (ctxt->error != XPATH_EXPRESSION_OK) {
-			    xmlXPathFreeObject(obj);
-			    return(0);
+                            xmlXPtrFreeLocationSet(newlocset);
+                            goto filter_xptr_error;
 			}
 
                         /*
@@ -13793,19 +13650,17 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                             res = valuePop(ctxt);
 			    xmlXPathReleaseObject(ctxt->context, res);
                         }
-
-                        ctxt->context->node = NULL;
                     }
 
                     /*
                      * The result is used as the new evaluation locset.
                      */
-		    xmlXPathReleaseObject(ctxt->context, obj);
-                    ctxt->context->node = NULL;
-                    ctxt->context->contextSize = -1;
-                    ctxt->context->proximityPosition = -1;
                     valuePush(ctxt, xmlXPtrWrapLocationSet(newlocset));
+filter_xptr_error:
+		    xmlXPathReleaseObject(ctxt->context, obj);
                     ctxt->context->node = oldnode;
+                    ctxt->context->contextSize = oldcs;
+                    ctxt->context->proximityPosition = oldpp;
                     return (total);
                 }
 #endif /* LIBXML_XPTR_ENABLED */
@@ -13816,30 +13671,15 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                  * up a new set.
                  */
                 CHECK_TYPE0(XPATH_NODESET);
-                obj = valuePop(ctxt);
-                oldset = obj->nodesetval;
 
-                oldnode = ctxt->context->node;
-		oldDoc = ctxt->context->doc;
-                ctxt->context->node = NULL;
-
-                if ((oldset == NULL) || (oldset->nodeNr == 0)) {
-                    ctxt->context->contextSize = 0;
-                    ctxt->context->proximityPosition = 0;
-/*
-                    if (op->ch2 != -1)
-                        total +=
-                            xmlXPathCompOpEval(ctxt,
-                                               &comp->steps[op->ch2]);
-		    CHECK_ERROR0;
-                    res = valuePop(ctxt);
-                    if (res != NULL)
-                        xmlXPathFreeObject(res);
-*/
-                    valuePush(ctxt, obj);
-                    ctxt->context->node = oldnode;
-                    CHECK_ERROR0;
-                } else {
+                if ((ctxt->value->nodesetval != NULL) &&
+                    (ctxt->value->nodesetval->nodeNr != 0)) {
+                    obj = valuePop(ctxt);
+                    oldset = obj->nodesetval;
+                    oldnode = ctxt->context->node;
+                    oldDoc = ctxt->context->doc;
+                    oldcs = ctxt->context->contextSize;
+                    oldpp = ctxt->context->proximityPosition;
 		    tmp = NULL;
                     /*
                      * Initialize the new set.
@@ -13905,8 +13745,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                                    &comp->steps[op->ch2]);
 			if (ctxt->error != XPATH_EXPRESSION_OK) {
 			    xmlXPathFreeNodeSet(newset);
-			    xmlXPathFreeObject(obj);
-			    return(0);
+                            goto filter_error;
 			}
 
                         /*
@@ -13940,23 +13779,21 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
 			    */
                         } else
 			    tmp = NULL;
-                        ctxt->context->node = NULL;
                     }
 		    if (tmp != NULL)
 			xmlXPathReleaseObject(ctxt->context, tmp);
                     /*
                      * The result is used as the new evaluation set.
                      */
-		    xmlXPathReleaseObject(ctxt->context, obj);
-                    ctxt->context->node = NULL;
-                    ctxt->context->contextSize = -1;
-                    ctxt->context->proximityPosition = -1;
-		    /* may want to move this past the '}' later */
-		    ctxt->context->doc = oldDoc;
 		    valuePush(ctxt,
 			xmlXPathCacheWrapNodeSet(ctxt->context, newset));
+filter_error:
+		    xmlXPathReleaseObject(ctxt->context, obj);
+		    ctxt->context->node = oldnode;
+		    ctxt->context->doc = oldDoc;
+                    ctxt->context->contextSize = oldcs;
+                    ctxt->context->proximityPosition = oldpp;
                 }
-                ctxt->context->node = oldnode;
                 return (total);
             }
         case XPATH_OP_SORT:
@@ -13979,6 +13816,9 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 xmlLocationSetPtr newlocset = NULL;
 		    xmlLocationSetPtr oldlocset;
                 xmlNodeSetPtr oldset;
+                xmlNodePtr oldnode = ctxt->context->node;
+                int oldcs = ctxt->context->contextSize;
+                int oldpp = ctxt->context->proximityPosition;
                 int i, j;
 
                 if (op->ch1 != -1) {
@@ -13999,22 +13839,14 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                      * up a new locset.
                      */
                     CHECK_TYPE0(XPATH_LOCATIONSET);
+
+                    if ((ctxt->value->user == NULL) ||
+                        (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
+                        return (total);
+
                     obj = valuePop(ctxt);
                     oldlocset = obj->user;
 
-                    if ((oldlocset == NULL) || (oldlocset->locNr == 0)) {
-		        ctxt->context->node = NULL;
-                        ctxt->context->contextSize = 0;
-                        ctxt->context->proximityPosition = 0;
-                        total += xmlXPathCompOpEval(ctxt,&comp->steps[op->ch2]);
-                        res = valuePop(ctxt);
-                        if (res != NULL) {
-			    xmlXPathReleaseObject(ctxt->context, res);
-			}
-                        valuePush(ctxt, obj);
-                        CHECK_ERROR0;
-                        return (total);
-                    }
                     newlocset = xmlXPtrLocationSetCreate(NULL);
 
                     for (i = 0; i < oldlocset->locNr; i++) {
@@ -14034,8 +13866,8 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                 xmlXPathCompOpEval(ctxt,
                                                    &comp->steps[op->ch2]);
 			if (ctxt->error != XPATH_EXPRESSION_OK) {
-			    xmlXPathFreeObject(obj);
-			    return(0);
+                            xmlXPtrFreeLocationSet(newlocset);
+                            goto rangeto_error;
 			}
 
                         res = valuePop(ctxt);
@@ -14070,14 +13902,11 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                             res = valuePop(ctxt);
 			    xmlXPathReleaseObject(ctxt->context, res);
                         }
-
-                        ctxt->context->node = NULL;
                     }
 		} else {	/* Not a location set */
                     CHECK_TYPE0(XPATH_NODESET);
                     obj = valuePop(ctxt);
                     oldset = obj->nodesetval;
-                    ctxt->context->node = NULL;
 
                     newlocset = xmlXPtrLocationSetCreate(NULL);
 
@@ -14100,8 +13929,8 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                     xmlXPathCompOpEval(ctxt,
                                                    &comp->steps[op->ch2]);
 			    if (ctxt->error != XPATH_EXPRESSION_OK) {
-				xmlXPathFreeObject(obj);
-				return(0);
+                                xmlXPtrFreeLocationSet(newlocset);
+                                goto rangeto_error;
 			    }
 
                             res = valuePop(ctxt);
@@ -14122,8 +13951,6 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                 res = valuePop(ctxt);
 				xmlXPathReleaseObject(ctxt->context, res);
                             }
-
-                            ctxt->context->node = NULL;
                         }
                     }
                 }
@@ -14131,11 +13958,12 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 /*
                  * The result is used as the new evaluation set.
                  */
-		xmlXPathReleaseObject(ctxt->context, obj);
-                ctxt->context->node = NULL;
-                ctxt->context->contextSize = -1;
-                ctxt->context->proximityPosition = -1;
                 valuePush(ctxt, xmlXPtrWrapLocationSet(newlocset));
+rangeto_error:
+		xmlXPathReleaseObject(ctxt->context, obj);
+                ctxt->context->node = oldnode;
+                ctxt->context->contextSize = oldcs;
+                ctxt->context->proximityPosition = oldpp;
                 return (total);
             }
 #endif /* LIBXML_XPTR_ENABLED */

--- a/sdk/lib/3rdparty/libxml2/xzlib.c
+++ b/sdk/lib/3rdparty/libxml2/xzlib.c
@@ -562,6 +562,10 @@ xz_decomp(xz_statep state)
                          "internal error: inflate stream corrupt");
                 return -1;
             }
+            /*
+             * FIXME: Remapping a couple of error codes and falling through
+             * to the LZMA error handling looks fragile.
+             */
             if (ret == Z_MEM_ERROR)
                 ret = LZMA_MEM_ERROR;
             if (ret == Z_DATA_ERROR)
@@ -585,6 +589,11 @@ xz_decomp(xz_statep state)
         }
         if (ret == LZMA_PROG_ERROR) {
             xz_error(state, LZMA_PROG_ERROR, "compression error");
+            return -1;
+        }
+        if ((state->how != GZIP) &&
+            (ret != LZMA_OK) && (ret != LZMA_STREAM_END)) {
+            xz_error(state, ret, "lzma error");
             return -1;
         }
     } while (strm->avail_out && ret != LZMA_STREAM_END);


### PR DESCRIPTION
## Purpose

fix for uninitialized Lun pointer, CORE-15886
This fixes crash on Intel AHCI init

JIRA issue: [CORE-15886](https://jira.reactos.org/browse/CORE-15886)

## Proposed changes

AtapiSetupLunPtrs() was not called after UniataAllocateLunExt() in Intel SATA/AHCI detect code. It is necessary to do it at this moment because
we have to setup LUN-specfic flags at this moment.

